### PR TITLE
Fix field names in mapping headers

### DIFF
--- a/value-maps/profileName2resourceClass_tf-extended_noResourceClassProfiles.csv
+++ b/value-maps/profileName2resourceClass_tf-extended_noResourceClassProfiles.csv
@@ -1,4 +1,4 @@
-_COMPONENTPROFILE,RESOURCECLASS,TF-applicability,TF-note,TF-COUNT,TF-pivot-count:collection,TF-pivot-members:collection
+_componentProfile,resourceClass,TF-applicability,TF-note,TF-COUNT,TF-pivot-count:collection,TF-pivot-members:collection
 AnnotatedCorpusProfile-DLU,"","","",3,1,"TST-Centrale |3|"
 BatImageBundle,"","","",11,1,"MPI corpora : Neurogenetics of Vocal Communication |11|"
 CRM,"","","",95,1,"Meertens collection: CRM |95|"

--- a/value-maps/resourceClass_tf-extended.csv
+++ b/value-maps/resourceClass_tf-extended.csv
@@ -1,4 +1,4 @@
-RESOURCECLASS,RESOURCECLASS,TF-applicability,TF-note,TF-COUNT,TF-pivot-count:collection,TF-pivot-members:collection
+resourceClass,resourceClass,TF-applicability,TF-note,TF-COUNT,TF-pivot-count:collection,TF-pivot-members:collection
 Aikataulut,"text","","",23,1,"National Library of Finland, Ephemera: Travel Brochures |23|"
 Alter Druck,"text","","",5,1,"Universität des Saarlandes CLARIN-D-Zentrum, Saarbrücken |5|"
 Amateurfilm,"video","","",12,1,"Nederlands Instituut voor Beeld en Geluid Academia collectie |12|"


### PR DESCRIPTION
Field names are treated in a case sensitive manner by the importer. Therefore the all-upper-case field names in the CSV headers must be replaced with the actual field names with proper case.